### PR TITLE
Main

### DIFF
--- a/templates/partials/social_login.html
+++ b/templates/partials/social_login.html
@@ -2,7 +2,7 @@
     <a href = "{% url 'users:github-login' %}">
         Continue with GitHub.
     </a>
-    <a>
+    <a href = "{% url 'users:kakao-login' %}">
         Continue with Kakao.
     </a>
 </div>

--- a/users/urls.py
+++ b/users/urls.py
@@ -5,8 +5,13 @@ app_name = "users"
 
 urlpatterns = [
     path("login", views.LoginView.as_view(), name="login"),
+    # git hub login
     path("login/github", views.github_login, name="github-login"),
     path("login/github/callback", views.github_callback, name="github-callback"),
+    # kakao login
+    path("login/kakao", views.kakao_login, name="kakao-login"),
+    path("login/kakao/callback", views.kakao_callback, name="kakao-callback"),
+    #
     path("logout", views.log_out, name="logout"),
     path("signup", views.SignUpView.as_view(), name="signup"),
     path("verify/<str:key>", views.complete_verification, name="complete_verification"),


### PR DESCRIPTION
22.04.02 
1. github 로그인
 1) 깃헙 회원이 웹사이트에 가입되어 있을 경우
   - login 처리 후 home으로 redirect한다
  2) 깃헙 회원이 웹사이트에 가입되어 있지 않은 경우
   - models.User.objects.create()를 통해 해당 회원을 웹사이트에 가입시켜준다.
  3) 예외처리
   - 에러 발생시 대부분 login화면으로 다시 돌아가므로, GithubException을 만든 뒤 공통으로 사용하게 함.
 
2. Kakao 로그인
  1) 구동방식
    - 작동방식은 git과 동일하다
    - 먼저 서버로부터 code를 받은 뒤 이 코드를 가지고 token 과 교환, 이걸로 api에 접근함.
   2) 막힌 부부
    - api로부터 받아온 json에 nickname이나 profile_photo가 없다.....강의 댓글을 보면 메일 계정으로만 카카오에 가입한 경우 이런 문제가 있다고는 하는데, 카카오doc에서 아직 찾질 못했음ㅜㅜ