### PR TITLE
22.04.05 sign up with UserCreationForm

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -156,3 +156,5 @@ EMAIL_PORT = "587"
 EMAIL_HOST_USER = os.environ.get("MAILGUN_USERNAME")
 EMAIL_HOST_PASSWORD = os.environ.get("MAILGUN_PASSWORD")
 EMAIL_FROM = "sexy-guy@sandboxa775f8a3470345028f678a8889e60baf.mailgun.org"
+
+AUTH_USER_MODEL = "users.User"

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.forms import UserCreationForm
 from . import models
 
 
@@ -23,34 +24,11 @@ class LoginForm(forms.Form):
             self.add_error("email", forms.ValidationError("User does not exist"))
 
 
-class SignUpForm(forms.ModelForm):
+class SignUpForm(UserCreationForm):
 
-    ## Model Form은 field의 uniqueness를 알아서 검증해준다
+    username = forms.EmailField(label="Email")
+
     class Meta:
         model = models.User
-        fields = ("first_name", "last_name", "email")
-
-    password = forms.CharField(widget=forms.PasswordInput)
-    password1 = forms.CharField(widget=forms.PasswordInput, label="Confirm Password")
-
-    def clean_password1(self):
-        password = self.cleaned_data.get("password")
-        password1 = self.cleaned_data.get("password1")
-
-        if password != password1:
-            raise forms.ValidationError("Password confirmation does not match!")
-        else:
-            return password
-
-    def save(self, commit: bool = ...):
-        user = super().save(commit=False)
-        # 위의 정보로 user객체를 생성하긴 하는데 db에 commit은 안함
-
-        email = self.cleaned_data.get("email")
-        password = self.cleaned_data.get("password")
-        user.username = email
-        user.set_password(password)
-
-        print(user.username)
-        user.save()
-        # 새로 원하는 필드값을 만든 뒤에 user객체에 덮어씌우기 후 save & commit
+        fields = ("email",)
+        # 오버라이딩을 하여 modelForm을 사용했으면, fields도 오버라이딩 해주든지 해야함

--- a/users/views.py
+++ b/users/views.py
@@ -7,6 +7,7 @@ from django.urls import reverse_lazy
 from django.shortcuts import render, redirect, reverse
 from django.contrib.auth import authenticate, login, logout
 from django.core.files.base import ContentFile
+from django.contrib.auth.forms import UserCreationForm
 from . import forms, models
 
 
@@ -47,6 +48,7 @@ def log_out(request):
 class SignUpView(FormView):
     template_name = "users/signup.html"
     form_class = forms.SignUpForm
+    # form_class = UserCreationForm
     success_url = reverse_lazy("core:home")
     initial = {
         "first_name": "Jaeuk",


### PR DESCRIPTION
22.04.05
1. signup form변경
 1)signup form을 기존에 직접 만든것이 아닌 built-in인 UserCreationForm으로 변경
   - password validation등을 직접 구현해줌
   - 문제는 1. meta 클래스를 오버라이딩해서 model을 내가 만든 model.User로 변경해주지 않으면 안됨
   - 2. validation을 위한 이메일 발송시 사용되는 user.verify_email() 함수 호출에서 user객체가 verify_email() 메서드를 갖고있지 않음.
   - 따라서, UserCreationForm은 사용하지 않고 안에 있는 password_validation만 사용해보자