### PR TITLE
22.04.11 tail wind - almost finished

### DIFF
--- a/templates/partials/social_login.html
+++ b/templates/partials/social_login.html
@@ -1,11 +1,11 @@
 <div class="flex flex-col w-full">
     <a href = "{% url 'users:github-login' %}" 
-        class="w-full border-2 font-medium text-gray-700 border-gray-700 text-center rounded-sm py-5">
+        class="w-full border-2 font-medium text-lg text-gray-700 border-gray-700 text-center rounded-sm py-5">
       <i class="fab fa-github-alt mr-2 fa-lg"> </i>  
       Continue with GitHub.
     </a>
     <a href = "{% url 'users:kakao-login' %}"  
-        class="w-full border-2 font-medium text-yellow-900 border-yellow-400 text-center rounded-sm py-5 bg-yellow-400">
+        class="w-full border-2 font-medium text-lg text-yellow-900 border-yellow-400 text-center rounded-sm py-5 bg-yellow-400">
         <i class="fas fa-comment mr-2 fa-lg"> </i>  
         Continue with Kakao.
     </a>

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -11,11 +11,23 @@
     <div class="container lg:w-5/12 md:w-1/2 xl:w-5/12 mx-auto my-10 flex flex-col items-center border p-6 border-gray-400">
             {% include "partials/social_login.html" %}
         
-            <form method="POST" action="{% url 'users:login' %}">
+            <div class="flex items-center my-5">
+                <div class="h-px w-full bg-gray-800"></div>
+                <span class="text-gray-700 font-medium mx-4 texgt-sm">or</span>
+                <div class="h-px w-full bg-gray-800"></div>
+
+            </div>
+
+            <form method="POST" action="{% url 'users:login' %}" class="w-full my-3">
                 {% csrf_token %}
-                {{form.as_p}}
-                <button>Login</button>
+                <!-- {{form.as_p}} -->
+                <input type="email" placeholder="Email" class="w-full border-2 font-medium text-lg rounded py-5 text-left border-gray-700 px-5 focus:outline-none focus:border-teal-500 mb-3">
+                <input type="password" placeholder="Password" class="w-full border-2 font-medium text-lg rounded py-5 text-left border-gray-700 px-5 focus:outline-none focus:border-teal-500 mb-3">
+                <button class="w-full border-2 font-medium text-lg text-white text-center rounded-sm py-5 bg-red-500">Login</button>
             </form>
+        <div class="mr-2">
+        <span>Don't have and account?</span> <a href="{% url 'users:signup' %}" class="text-teal-500 font-medium">Sign Up</a>
+        </div>
     </div>
 
 {% endblock content %}

--- a/templates/users/signup.html
+++ b/templates/users/signup.html
@@ -10,11 +10,54 @@
 
 {% block content %}
 
-    {% include "partials/social_login.html" %}
+<div class="container lg:w-5/12 md:w-1/2 xl:w-5/12 mx-auto my-10 flex flex-col items-center border p-6 border-gray-400">
+ 
 
-    <form method="POST" action="{% url 'users:signup' %}">
-        {% csrf_token %}
-        {{form.as_p}}
-        <button>Sign Up</button>
-    </form>
+        {% include "partials/social_login.html" %}
+        
+        <form method="POST" action="{% url 'users:signup' %}" >
+            {% csrf_token %}
+
+            
+            {% if form.non_field_errors %}
+
+                {% for error in form.non_field_errors %}
+                <span class="text-red-700 font-medium text-sm">{{error}}</span> 
+                {% endfor %}    
+
+            {% endif %}
+                
+
+            <!-- {{form.first_name}}
+            {{form.last_name}}
+            {{form.email}}
+
+            {{form.password}}
+            {{form.password1}} -->
+            <!-- {{form.as_p}} -->
+<!-- 
+            {% for field in form %}
+              <div class="input">
+                  {{field}}
+              </div>
+            {% endfor %} -->
+
+
+        {% for field in form %}
+            <div class="input w-full {% if field.errors %}has_error{% endif %}">
+                {{field}}
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <span class="text-red-700 font-medium text-sm">{{error}}</span> 
+                    {% endfor %}
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        <button class="w-full border-2 font-medium text-lg text-white text-center rounded-sm py-5 bg-red-500">Sign Up</button>
+        </form>
+        <div class="mr-2">
+            <span>Have an account?</span> <a href="{% url 'users:login' %}" class="text-teal-500 font-medium">Log In</a>
+            </div>
+    </div>
 {% endblock content %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -9,8 +9,10 @@ from . import models
 
 
 class LoginForm(forms.Form):
-    email = forms.EmailField()
-    password = forms.CharField(widget=forms.PasswordInput)
+    email = forms.EmailField(widget=forms.EmailInput(attrs={"placeholder": "Email"}))
+    password = forms.CharField(
+        widget=forms.PasswordInput(attrs={"placeholeder": "Password"})
+    )
 
     # 해당 필드값을 확인하고 싶은 경우 반드시 "clean_"이어야 함.
 
@@ -24,7 +26,7 @@ class LoginForm(forms.Form):
             if user.check_password(password):
                 return self.cleaned_data
             else:
-                self.add_error("password", forms.ValidationError("Password is wrong"))
+                self.add_error(None, forms.ValidationError("Password is wrong"))
         except models.User.DoesNotExist:
             self.add_error("email", forms.ValidationError("User does not exist"))
 
@@ -35,9 +37,28 @@ class SignUpForm(forms.ModelForm):
     class Meta:
         model = models.User
         fields = ("first_name", "last_name", "email")
+        widgets = {
+            "first_name": forms.TextInput(attrs={"placeholder": "First Name"}),
+            "last_name": forms.TextInput(attrs={"placeholder": "Last Name"}),
+            "email": forms.TextInput(attrs={"placeholder": "Email"}),
+        }
 
-    password = forms.CharField(widget=forms.PasswordInput)
-    password1 = forms.CharField(widget=forms.PasswordInput, label="Confirm Password")
+    password = forms.CharField(
+        widget=forms.PasswordInput(attrs={"placeholder": "Password"})
+    )
+    password1 = forms.CharField(
+        widget=forms.PasswordInput(attrs={"placeholder": "Confirm Password"}),
+    )
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        try:
+            models.User.objects.get(email=email)
+            raise forms.ValidationError(
+                "That email is already taken", code="existing_user"
+            )
+        except models.User.DoesNotExist:
+            return email
 
     def clean_password1(self):
         password = self.cleaned_data.get("password")

--- a/users/views.py
+++ b/users/views.py
@@ -50,11 +50,11 @@ class SignUpView(FormView):
     form_class = forms.SignUpForm
     # form_class = UserCreationForm
     success_url = reverse_lazy("core:home")
-    initial = {
-        "first_name": "Jaeuk",
-        "last_name": "Ko",
-        "email": "endlesswaltz0@naver.com",
-    }
+    # initial = {
+    #     "first_name": "Jaeuk",
+    #     "last_name": "Ko",
+    #     "email": "endlesswaltz0@naver.com",
+    # }
 
     def form_valid(self, form):
         form.save()


### PR DESCRIPTION
"22.04.11" tailwind css
1. Sign Up 시 email 계정 dup이 나는 문제 해결
 - sign up form에 clean_email 메서드 추가해줌. 이거 안해주니 듑 여부를 미리 처리해주지 못한거
 - 
2. signup.html에서 as_p
 - form의 필드를 자동으로 html로 만들어주는 as_p 대신 form.name 등 필드를 하나하나 따로 입력하도록 바꿈, 에러처리를 위함
 - 처음에는 안됐는데 나중에는 됐음 왜 처음에는 안됐지?

 3. form에서 placeholder를 지정해줌.
 4. 모든 필드에는 error가 있음. 따라서 signup.html에서 field.error로 에러 여부를 확인한뒤 그에 맞는 처리를 해줌